### PR TITLE
Enable card_payments capability for new Stripe accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ The seller onboarding uses a modern vertical stepper inspired by popular store
 builders. Each step presents a full-width card guiding the user from connecting
 Stripe to paying the platform fee.
 
+New accounts are created with the `card_payments` and `transfers` capabilities
+requested so sellers can accept payments and receive payouts once verified.
+
 ## Seller Subscription
 
 After completing the verification step the onboarding flow presents a

--- a/app/api/stripe/onboard/route.ts
+++ b/app/api/stripe/onboard/route.ts
@@ -29,7 +29,13 @@ export async function POST(request: Request) {
         { status: 500 }
       )
     }
-    const account = await stripe.accounts.create({ type: "express" })
+    const account = await stripe.accounts.create({
+      type: "express",
+      capabilities: {
+        card_payments: { requested: true },
+        transfers: { requested: true },
+      },
+    })
     const db = await getDb().catch(() => null)
     if (db) {
       let userId: ObjectId | null = null


### PR DESCRIPTION
## Summary
- request `card_payments` and `transfers` capabilities when creating connected Stripe accounts
- note in README that accounts request these capabilities during onboarding

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858d17734788329ae397ba7a3af2750