### PR TITLE
Add buyers management for sellers

### DIFF
--- a/__tests__/api/buyers.test.ts
+++ b/__tests__/api/buyers.test.ts
@@ -1,0 +1,61 @@
+import { GET } from '@/app/api/buyers/route'
+import { getDb } from '@/lib/mongo'
+import { ObjectId } from 'mongodb'
+
+jest.mock('@/lib/mongo')
+
+const mockGetDb = getDb as jest.Mock
+const mockCookies = jest.fn()
+
+jest.mock('next/headers', () => ({
+  cookies: () => mockCookies(),
+}))
+
+describe('GET /api/buyers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns empty array when unauthenticated', async () => {
+    mockCookies.mockReturnValue({ get: () => undefined })
+    mockGetDb.mockResolvedValue({ collection: jest.fn() })
+
+    const res = await GET()
+    const json = await res.json()
+    expect(res.status).toBe(200)
+    expect(json.buyers).toEqual([])
+  })
+
+  it('returns buyers list for seller', async () => {
+    const session = { token: 't', userId: new ObjectId('507f191e810c19729de860ea') }
+    const purchase = {
+      _id: new ObjectId('507f191e810c19729de860eb'),
+      userId: new ObjectId('507f191e810c19729de860ec'),
+      productId: new ObjectId('507f191e810c19729de860ed'),
+      status: 'paid',
+      createdAt: new Date('2024-01-01T00:00:00Z'),
+      paymentIntentId: 'pi_1',
+      sellerId: 'acct_1',
+      buyerName: 'Buyer',
+      buyerEmail: 'b@example.com',
+      productName: 'Prod',
+    }
+    const aggregate = jest.fn().mockReturnValue({ toArray: () => [purchase] })
+    mockCookies.mockReturnValue({ get: () => ({ value: 't' }) })
+    mockGetDb.mockResolvedValue({
+      collection: (name: string) => {
+        if (name === 'sessions') return { findOne: jest.fn().mockResolvedValue(session) }
+        if (name === 'sellers') return { findOne: jest.fn().mockResolvedValue({ _id: 'acct_1' }) }
+        if (name === 'purchases') return { aggregate }
+        return { findOne: jest.fn() }
+      },
+    })
+
+    const res = await GET()
+    const json = await res.json()
+    expect(res.status).toBe(200)
+    expect(json.buyers.length).toBe(1)
+    expect(json.buyers[0].productName).toBe('Prod')
+    expect(aggregate).toHaveBeenCalled()
+  })
+})

--- a/app/api/buyers/route.ts
+++ b/app/api/buyers/route.ts
@@ -1,0 +1,89 @@
+import { NextResponse } from 'next/server'
+import { cookies } from 'next/headers'
+import { getDb } from '@/lib/mongo'
+import { ObjectId } from 'mongodb'
+
+export async function GET() {
+  try {
+    const db = await getDb()
+    const cookieStore = await cookies()
+    const token = cookieStore.get('session')?.value
+    if (!token) return NextResponse.json({ buyers: [] })
+    const session = await db
+      .collection<{ token: string; userId: ObjectId }>('sessions')
+      .findOne({ token })
+    if (!session) return NextResponse.json({ buyers: [] })
+    const seller = await db
+      .collection<{ _id: string }>('sellers')
+      .findOne({ userId: session.userId })
+    if (!seller) return NextResponse.json({ buyers: [] })
+    const purchases = await db
+      .collection<{
+        _id: ObjectId
+        userId: ObjectId
+        productId: ObjectId
+        status: string
+        createdAt: Date
+        invoiceId?: string
+        subscriptionId?: string
+        paymentIntentId?: string
+        sellerId: string
+      }>('purchases')
+      .aggregate([
+        { $match: { sellerId: seller._id } },
+        {
+          $lookup: {
+            from: 'products',
+            localField: 'productId',
+            foreignField: '_id',
+            as: 'product',
+          },
+        },
+        { $unwind: '$product' },
+        {
+          $lookup: {
+            from: 'users',
+            localField: 'userId',
+            foreignField: '_id',
+            as: 'user',
+          },
+        },
+        { $unwind: '$user' },
+        {
+          $project: {
+            status: 1,
+            createdAt: 1,
+            invoiceId: 1,
+            subscriptionId: 1,
+            paymentIntentId: 1,
+            sellerId: 1,
+            productId: 1,
+            userId: 1,
+            productName: '$product.name',
+            buyerName: '$user.name',
+            buyerEmail: '$user.email',
+          },
+        },
+        { $sort: { createdAt: -1 } },
+      ])
+      .toArray()
+    const formatted = purchases.map((p) => ({
+      _id: p._id.toString(),
+      productId: p.productId.toString(),
+      userId: p.userId.toString(),
+      status: p.status,
+      createdAt: p.createdAt.toISOString(),
+      invoiceId: p.invoiceId,
+      subscriptionId: p.subscriptionId,
+      paymentIntentId: p.paymentIntentId,
+      sellerId: p.sellerId,
+      productName: p.productName,
+      buyerName: p.buyerName,
+      buyerEmail: p.buyerEmail,
+    }))
+    return NextResponse.json({ buyers: formatted })
+  } catch (err) {
+    console.error(err)
+    return NextResponse.json({ error: 'Failed to fetch' }, { status: 500 })
+  }
+}

--- a/app/buyers/columns.tsx
+++ b/app/buyers/columns.tsx
@@ -1,0 +1,63 @@
+"use client"
+
+import { ColumnDef } from "@tanstack/react-table"
+import { MoreHorizontal } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+
+export type BuyerPurchase = {
+  _id: string
+  buyerName: string
+  buyerEmail: string
+  productName: string
+  status: string
+  createdAt: string
+  paymentIntentId?: string
+}
+
+export function getColumns(
+  onRefund: (id: string) => void,
+): ColumnDef<BuyerPurchase>[] {
+  return [
+    { accessorKey: "buyerName", header: "Name" },
+    { accessorKey: "buyerEmail", header: "Email" },
+    { accessorKey: "productName", header: "Product" },
+    {
+      accessorKey: "createdAt",
+      header: "Date",
+      cell: ({ row }) =>
+        new Date(row.getValue<string>("createdAt")).toLocaleDateString(),
+    },
+    { accessorKey: "status", header: "Status" },
+    {
+      id: "actions",
+      cell: ({ row }) => {
+        const p = row.original
+        return (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" className="h-8 w-8 p-0">
+                <span className="sr-only">Open menu</span>
+                <MoreHorizontal className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuLabel>Actions</DropdownMenuLabel>
+              {p.paymentIntentId && (
+                <DropdownMenuItem onClick={() => onRefund(p._id)}>
+                  Refund
+                </DropdownMenuItem>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )
+      },
+    },
+  ]
+}

--- a/app/buyers/page.tsx
+++ b/app/buyers/page.tsx
@@ -1,0 +1,50 @@
+"use client"
+import { useEffect, useState } from 'react'
+import DashboardLayout from '@/components/dashboard-layout'
+import { DataTable } from '@/components/ui/data-table'
+import { Spinner } from '@/components/ui/spinner'
+import { toast } from 'sonner'
+import { getColumns, BuyerPurchase } from './columns'
+
+export default function BuyersPage() {
+  const [items, setItems] = useState<BuyerPurchase[] | null>(null)
+
+  useEffect(() => {
+    fetch('/api/buyers')
+      .then((res) => res.json())
+      .then((data) => setItems(data.buyers || []))
+      .catch(() => setItems([]))
+  }, [])
+
+  async function handleRefund(id: string) {
+    if (!items) return
+    await toast.promise(
+      (async () => {
+        const res = await fetch(`/api/purchases/${id}/refund`, { method: 'POST' })
+        if (!res.ok) throw new Error('Failed')
+        setItems((prev) =>
+          prev ? prev.map((p) => (p._id === id ? { ...p, status: 'refunded' } : p)) : prev
+        )
+      })(),
+      { loading: 'Refunding...', success: 'Refunded', error: 'Failed to refund' }
+    )
+  }
+
+  const help = <p>View your customers and refund purchases if needed.</p>
+
+  return (
+    <DashboardLayout title="Buyers" helpContent={help}>
+      <div className="p-6">
+        {items === null ? (
+          <div className="flex justify-center">
+            <Spinner className="size-6" />
+          </div>
+        ) : items.length === 0 ? (
+          <p>No buyers found.</p>
+        ) : (
+          <DataTable columns={getColumns(handleRefund)} data={items} />
+        )}
+      </div>
+    </DashboardLayout>
+  )
+}


### PR DESCRIPTION
## Summary
- allow sellers to refund any of their purchases
- show buyers with refund action using DataTable
- provide API endpoint for listing buyers
- test buyers API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a1e33f9248329b1ef2408f600d235