### PR TITLE
Rename invoice downloads to receipts

### DIFF
--- a/__tests__/api/receipt.test.ts
+++ b/__tests__/api/receipt.test.ts
@@ -49,10 +49,11 @@ describe('GET /api/purchases/[id]/receipt', () => {
     const json = await res.json()
     expect(res.status).toBe(200)
     expect(json.url).toBe('url')
-    expect(mockRetrievePI).toHaveBeenCalledWith('pi_1', {
-      stripeAccount: 'acct_1',
-      expand: ['charges'],
-    })
+    expect(mockRetrievePI).toHaveBeenCalledWith(
+      'pi_1',
+      { expand: ['charges'] },
+      { stripeAccount: 'acct_1' },
+    )
   })
 
   it('allows seller to download receipt', async () => {
@@ -78,10 +79,11 @@ describe('GET /api/purchases/[id]/receipt', () => {
     const json = await res.json()
     expect(res.status).toBe(200)
     expect(json.url).toBe('url')
-    expect(mockRetrievePI).toHaveBeenCalledWith('pi_2', {
-      stripeAccount: 'acct_1',
-      expand: ['charges'],
-    })
+    expect(mockRetrievePI).toHaveBeenCalledWith(
+      'pi_2',
+      { expand: ['charges'] },
+      { stripeAccount: 'acct_1' },
+    )
   })
 
   it('falls back to invoice if payment intent missing', async () => {
@@ -109,9 +111,10 @@ describe('GET /api/purchases/[id]/receipt', () => {
     expect(res.status).toBe(200)
     expect(json.url).toBe('url')
     expect(mockRetrieveInvoice).toHaveBeenCalledWith('in_1', { stripeAccount: 'acct_1' })
-    expect(mockRetrievePI).toHaveBeenCalledWith('pi_3', {
-      stripeAccount: 'acct_1',
-      expand: ['charges'],
-    })
+    expect(mockRetrievePI).toHaveBeenCalledWith(
+      'pi_3',
+      { expand: ['charges'] },
+      { stripeAccount: 'acct_1' },
+    )
   })
 })

--- a/__tests__/api/receipt.test.ts
+++ b/__tests__/api/receipt.test.ts
@@ -6,11 +6,13 @@ jest.mock('@/lib/mongo')
 
 const mockGetDb = getDb as jest.Mock
 const mockCookies = jest.fn()
-const mockRetrieve = jest.fn()
+const mockRetrievePI = jest.fn()
+const mockRetrieveInvoice = jest.fn()
 
 jest.mock('stripe', () => {
   return jest.fn().mockImplementation(() => ({
-    paymentIntents: { retrieve: mockRetrieve },
+    paymentIntents: { retrieve: mockRetrievePI },
+    invoices: { retrieve: mockRetrieveInvoice },
   }))
 })
 
@@ -32,7 +34,7 @@ describe('GET /api/purchases/[id]/receipt', () => {
       paymentIntentId: 'pi_1',
       sellerId: 'acct_1',
     }
-    mockRetrieve.mockResolvedValue({ charges: { data: [{ receipt_url: 'url' }] } })
+    mockRetrievePI.mockResolvedValue({ charges: { data: [{ receipt_url: 'url' }] } })
     mockCookies.mockReturnValue({ get: () => ({ value: 't' }) })
     mockGetDb.mockResolvedValue({
       collection: (name: string) => {
@@ -47,7 +49,7 @@ describe('GET /api/purchases/[id]/receipt', () => {
     const json = await res.json()
     expect(res.status).toBe(200)
     expect(json.url).toBe('url')
-    expect(mockRetrieve).toHaveBeenCalledWith('pi_1', { stripeAccount: 'acct_1' })
+    expect(mockRetrievePI).toHaveBeenCalledWith('pi_1', { stripeAccount: 'acct_1' })
   })
 
   it('allows seller to download receipt', async () => {
@@ -58,7 +60,7 @@ describe('GET /api/purchases/[id]/receipt', () => {
       paymentIntentId: 'pi_2',
       sellerId: 'acct_1',
     }
-    mockRetrieve.mockResolvedValue({ charges: { data: [{ receipt_url: 'url' }] } })
+    mockRetrievePI.mockResolvedValue({ charges: { data: [{ receipt_url: 'url' }] } })
     mockCookies.mockReturnValue({ get: () => ({ value: 't' }) })
     mockGetDb.mockResolvedValue({
       collection: (name: string) => {
@@ -73,6 +75,34 @@ describe('GET /api/purchases/[id]/receipt', () => {
     const json = await res.json()
     expect(res.status).toBe(200)
     expect(json.url).toBe('url')
-    expect(mockRetrieve).toHaveBeenCalledWith('pi_2', { stripeAccount: 'acct_1' })
+    expect(mockRetrievePI).toHaveBeenCalledWith('pi_2', { stripeAccount: 'acct_1' })
+  })
+
+  it('falls back to invoice if payment intent missing', async () => {
+    const session = { token: 't', userId: new ObjectId('507f191e810c19729de860ff') }
+    const purchase = {
+      _id: new ObjectId('507f191e810c19729de860ab'),
+      userId: session.userId,
+      invoiceId: 'in_1',
+      sellerId: 'acct_1',
+    }
+    mockRetrieveInvoice.mockResolvedValue({ payment_intent: 'pi_3' })
+    mockRetrievePI.mockResolvedValue({ charges: { data: [{ receipt_url: 'url' }] } })
+    mockCookies.mockReturnValue({ get: () => ({ value: 't' }) })
+    mockGetDb.mockResolvedValue({
+      collection: (name: string) => {
+        if (name === 'sessions') return { findOne: jest.fn().mockResolvedValue(session) }
+        if (name === 'purchases') return { findOne: jest.fn().mockResolvedValue(purchase), updateOne: jest.fn() }
+        if (name === 'sellers') return { findOne: jest.fn().mockResolvedValue(null) }
+        return { findOne: jest.fn() }
+      },
+    })
+
+    const res = await GET(new Request('http://localhost'), { params: { id: purchase._id.toString() } })
+    const json = await res.json()
+    expect(res.status).toBe(200)
+    expect(json.url).toBe('url')
+    expect(mockRetrieveInvoice).toHaveBeenCalledWith('in_1', { stripeAccount: 'acct_1' })
+    expect(mockRetrievePI).toHaveBeenCalledWith('pi_3', { stripeAccount: 'acct_1' })
   })
 })

--- a/__tests__/api/receipt.test.ts
+++ b/__tests__/api/receipt.test.ts
@@ -49,7 +49,10 @@ describe('GET /api/purchases/[id]/receipt', () => {
     const json = await res.json()
     expect(res.status).toBe(200)
     expect(json.url).toBe('url')
-    expect(mockRetrievePI).toHaveBeenCalledWith('pi_1', { stripeAccount: 'acct_1' })
+    expect(mockRetrievePI).toHaveBeenCalledWith('pi_1', {
+      stripeAccount: 'acct_1',
+      expand: ['charges'],
+    })
   })
 
   it('allows seller to download receipt', async () => {
@@ -75,7 +78,10 @@ describe('GET /api/purchases/[id]/receipt', () => {
     const json = await res.json()
     expect(res.status).toBe(200)
     expect(json.url).toBe('url')
-    expect(mockRetrievePI).toHaveBeenCalledWith('pi_2', { stripeAccount: 'acct_1' })
+    expect(mockRetrievePI).toHaveBeenCalledWith('pi_2', {
+      stripeAccount: 'acct_1',
+      expand: ['charges'],
+    })
   })
 
   it('falls back to invoice if payment intent missing', async () => {
@@ -103,6 +109,9 @@ describe('GET /api/purchases/[id]/receipt', () => {
     expect(res.status).toBe(200)
     expect(json.url).toBe('url')
     expect(mockRetrieveInvoice).toHaveBeenCalledWith('in_1', { stripeAccount: 'acct_1' })
-    expect(mockRetrievePI).toHaveBeenCalledWith('pi_3', { stripeAccount: 'acct_1' })
+    expect(mockRetrievePI).toHaveBeenCalledWith('pi_3', {
+      stripeAccount: 'acct_1',
+      expand: ['charges'],
+    })
   })
 })

--- a/app/api/purchases/[id]/receipt/route.ts
+++ b/app/api/purchases/[id]/receipt/route.ts
@@ -66,8 +66,9 @@ export async function GET(
   try {
     const intent = await getStripe().paymentIntents.retrieve(intentId, {
       stripeAccount: purchase.sellerId,
+      expand: ['charges'],
     })
-    const charge = intent.charges.data[0]
+    const charge = intent.charges?.data?.[0]
     const url = (charge as Stripe.Charge | undefined)?.receipt_url
     if (!url) throw new Error('Missing receipt')
     return NextResponse.json({ url })

--- a/app/api/purchases/[id]/receipt/route.ts
+++ b/app/api/purchases/[id]/receipt/route.ts
@@ -5,6 +5,7 @@ import { ObjectId } from 'mongodb'
 import Stripe from 'stripe'
 
 let stripe: Stripe | null = null
+
 function getStripe(): Stripe {
   if (stripe) return stripe
   const secretKey = process.env.STRIPE_SECRET_KEY
@@ -15,17 +16,28 @@ function getStripe(): Stripe {
 
 export async function GET(
   request: Request,
-  ctx: { params: { id: string } } | { params: Promise<{ id: string }> }
+  ctx: { params: { id: string } }
 ) {
-  const { id } = await (ctx as { params: { id: string } | Promise<{ id: string }> }).params
-  const cookieStore = await cookies()
+  const { id } = ctx.params
+
+  const cookieStore = cookies()
   const token = cookieStore.get('session')?.value
-  if (!token) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  if (!token) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
   const db = await getDb()
+
+  // Find session
   const sessionDoc = await db
     .collection<{ token: string; userId: ObjectId }>('sessions')
     .findOne({ token })
-  if (!sessionDoc) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  if (!sessionDoc) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  // Find purchase
   const purchase = await db
     .collection<{
       _id: ObjectId
@@ -35,46 +47,103 @@ export async function GET(
       sellerId: string
     }>('purchases')
     .findOne({ _id: new ObjectId(id) })
-  if (!purchase) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+
+  if (!purchase) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+
+  // Find seller (if user is the seller)
   const seller = await db
     .collection<{ _id: string; userId: ObjectId }>('sellers')
     .findOne({ userId: sessionDoc.userId })
+
   const isBuyer = purchase.userId.equals(sessionDoc.userId)
   const isSeller = seller?._id === purchase.sellerId
-  if (!isBuyer && !isSeller)
+
+  if (!isBuyer && !isSeller) {
     return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+
   let intentId = purchase.paymentIntentId
+
+  // Retrieve PaymentIntent ID from invoice if missing
   if (!intentId && purchase.invoiceId) {
     try {
-      const invoice = await getStripe().invoices.retrieve(purchase.invoiceId, {
-        stripeAccount: purchase.sellerId,
-      })
-      intentId = typeof invoice.payment_intent === 'string'
-        ? invoice.payment_intent
-        : invoice.payment_intent?.id
-      if (intentId) {
-        await db
-          .collection('purchases')
-          .updateOne({ _id: purchase._id }, { $set: { paymentIntentId: intentId } })
+      const invoice = await getStripe().invoices.retrieve(
+        purchase.invoiceId,
+        { stripeAccount: purchase.sellerId }
+      )
+      if (invoice.payment_intent) {
+        intentId = typeof invoice.payment_intent === 'string'
+          ? invoice.payment_intent
+          : invoice.payment_intent.id
+        if (intentId) {
+          await db
+            .collection('purchases')
+            .updateOne(
+              { _id: purchase._id },
+              { $set: { paymentIntentId: intentId } }
+            )
+        }
       }
     } catch (err) {
       console.error(err)
+      return NextResponse.json({
+        error: 'Failed to retrieve invoice',
+        details: err instanceof Error ? err.message : String(err),
+      }, { status: 500 })
     }
   }
-  if (!intentId)
+
+  if (!intentId) {
     return NextResponse.json({ error: 'No payment' }, { status: 404 })
+  }
+
   try {
+    // Retrieve PaymentIntent and expand charges
     const intent = await getStripe().paymentIntents.retrieve(
       intentId,
       { expand: ['charges'] },
-      { stripeAccount: purchase.sellerId },
+      { stripeAccount: purchase.sellerId }
     )
-    const charge = intent.charges?.data?.[0]
-    const url = (charge as Stripe.Charge | undefined)?.receipt_url
-    if (!url) throw new Error('Missing receipt')
-    return NextResponse.json({ url })
+
+    let charge
+
+    // Check expanded charges first
+    if (intent.charges?.data?.length) {
+      charge = intent.charges.data[0]
+    } else if (intent.latest_charge) {
+      // fallback: retrieve latest_charge directly
+      const latestChargeId = typeof intent.latest_charge === 'string'
+        ? intent.latest_charge
+        : intent.latest_charge.id
+
+      charge = await getStripe().charges.retrieve(
+        latestChargeId,
+        { stripeAccount: purchase.sellerId }
+      )
+    }
+
+    if (!charge) {
+      return NextResponse.json({
+        error: 'No charge found for this PaymentIntent',
+        details: `PaymentIntent status: ${intent.status}`,
+      }, { status: 404 })
+    }
+
+    if (!charge.receipt_url) {
+      return NextResponse.json({
+        error: 'Charge has no receipt_url',
+        details: charge.id,
+      }, { status: 404 })
+    }
+
+    return NextResponse.json({ url: charge.receipt_url })
   } catch (err) {
     console.error(err)
-    return NextResponse.json({ error: 'Failed to fetch receipt' }, { status: 500 })
+    return NextResponse.json({
+      error: 'Failed to fetch receipt',
+      details: err instanceof Error ? err.message : String(err),
+    }, { status: 500 })
   }
 }

--- a/app/api/purchases/[id]/receipt/route.ts
+++ b/app/api/purchases/[id]/receipt/route.ts
@@ -64,10 +64,11 @@ export async function GET(
   if (!intentId)
     return NextResponse.json({ error: 'No payment' }, { status: 404 })
   try {
-    const intent = await getStripe().paymentIntents.retrieve(intentId, {
-      stripeAccount: purchase.sellerId,
-      expand: ['charges'],
-    })
+    const intent = await getStripe().paymentIntents.retrieve(
+      intentId,
+      { expand: ['charges'] },
+      { stripeAccount: purchase.sellerId },
+    )
     const charge = intent.charges?.data?.[0]
     const url = (charge as Stripe.Charge | undefined)?.receipt_url
     if (!url) throw new Error('Missing receipt')

--- a/app/buyers/columns.tsx
+++ b/app/buyers/columns.tsx
@@ -27,7 +27,6 @@ export type BuyerPurchase = {
   currency?: string;
   status: string;
   createdAt: string;
-  invoiceId?: string;
   paymentIntentId?: string;
   refundRequest?: {
     status: string;
@@ -134,10 +133,10 @@ export function getColumns(
             <DropdownMenuContent align="end">
               <DropdownMenuLabel>Actions</DropdownMenuLabel>
               <DropdownMenuItem
-                onClick={() => onAction(p._id, "invoice")}
-                disabled={!p.invoiceId}
+                onClick={() => onAction(p._id, "receipt")}
+                disabled={!p.paymentIntentId}
               >
-                Download Invoice
+                Download Receipt
               </DropdownMenuItem>
               {p.paymentIntentId && p.status === "paid" && (
                 <DropdownMenuItem onClick={() => onAction(p._id, "refund")}>

--- a/app/buyers/columns.tsx
+++ b/app/buyers/columns.tsx
@@ -27,6 +27,7 @@ export type BuyerPurchase = {
   currency?: string;
   status: string;
   createdAt: string;
+  invoiceId?: string;
   paymentIntentId?: string;
   refundRequest?: {
     status: string;
@@ -134,7 +135,7 @@ export function getColumns(
               <DropdownMenuLabel>Actions</DropdownMenuLabel>
               <DropdownMenuItem
                 onClick={() => onAction(p._id, "receipt")}
-                disabled={!p.paymentIntentId}
+                disabled={!p.paymentIntentId && !p.invoiceId}
               >
                 Download Receipt
               </DropdownMenuItem>

--- a/app/buyers/page.tsx
+++ b/app/buyers/page.tsx
@@ -56,10 +56,10 @@ export default function BuyersPage() {
 
     if (action === "approve" || action === "decline") {
       setActionInfo({ id, type: action });
-    } else if (action === "invoice") {
+    } else if (action === "receipt") {
       // Open a blank tab immediately so popup blockers allow navigation
       const newTab = window.open("", "_blank");
-      const res = await fetch(`/api/purchases/${id}/invoice`);
+      const res = await fetch(`/api/purchases/${id}/receipt`);
       const data = await res.json().catch(() => ({}));
       if (res.ok && data.url) {
         if (newTab) newTab.location.href = data.url as string;

--- a/app/purchases/columns.tsx
+++ b/app/purchases/columns.tsx
@@ -26,6 +26,7 @@ export type Purchase = {
   currency?: string;
   status: string;
   createdAt: string;
+  invoiceId?: string;
   subscriptionId?: string;
   paymentIntentId?: string;
   customerId?: string;
@@ -138,7 +139,7 @@ export function getColumns(
               <DropdownMenuLabel>Actions</DropdownMenuLabel>
               <DropdownMenuItem
                 onClick={() => onAction(p._id, "receipt")}
-                disabled={!p.paymentIntentId}
+                disabled={!p.paymentIntentId && !p.invoiceId}
               >
                 Download Receipt
               </DropdownMenuItem>

--- a/app/purchases/columns.tsx
+++ b/app/purchases/columns.tsx
@@ -26,7 +26,6 @@ export type Purchase = {
   currency?: string;
   status: string;
   createdAt: string;
-  invoiceId?: string;
   subscriptionId?: string;
   paymentIntentId?: string;
   customerId?: string;
@@ -50,9 +49,8 @@ export function getColumns(
       cell: ({ row }) => {
         const p = row.original;
         const show =
-          p.invoiceId ||
-          p.subscriptionId ||
           p.paymentIntentId ||
+          p.subscriptionId ||
           p.refundRequest?.reason ||
           p.refundRequest?.sellerReason;
         if (!show) return null;
@@ -139,10 +137,10 @@ export function getColumns(
             <DropdownMenuContent align="end">
               <DropdownMenuLabel>Actions</DropdownMenuLabel>
               <DropdownMenuItem
-                onClick={() => onAction(p._id, "invoice")}
-                disabled={!p.invoiceId}
+                onClick={() => onAction(p._id, "receipt")}
+                disabled={!p.paymentIntentId}
               >
-                Download Invoice
+                Download Receipt
               </DropdownMenuItem>
               {p.subscriptionId && p.status !== "canceled" && (
                 <DropdownMenuItem onClick={() => onAction(p._id, "cancel")}>

--- a/app/purchases/page.tsx
+++ b/app/purchases/page.tsx
@@ -60,10 +60,10 @@ export default function PurchasesPage() {
   async function handleAction(id: string, action: string) {
     if (!items) return;
     switch (action) {
-      case "invoice": {
+      case "receipt": {
         // Open a blank tab immediately so popup blockers allow navigation
         const newTab = window.open("", "_blank");
-        const res = await fetch(`/api/purchases/${id}/invoice`);
+        const res = await fetch(`/api/purchases/${id}/receipt`);
         const data = await res.json().catch(() => ({}));
         if (res.ok && data.url) {
           if (newTab) newTab.location.href = data.url as string;
@@ -176,16 +176,11 @@ export default function PurchasesPage() {
               if (!expanded[p._id]) return null;
               return (
                 <div className="p-4 text-sm text-muted-foreground grid grid-cols-2 gap-2">
-                  {p.invoiceId && (
-                    <div className="col-span-1">Invoice: {p.invoiceId}</div>
+                  {p.paymentIntentId && (
+                    <div className="col-span-1">Receipt: {p.paymentIntentId}</div>
                   )}
                   {p.subscriptionId && (
                     <div className="col-span-1">Sub: {p.subscriptionId}</div>
-                  )}
-                  {p.paymentIntentId && (
-                    <div className="col-span-1">
-                      Payment: {p.paymentIntentId}
-                    </div>
                   )}
                   {p.refundRequest?.reason && (
                     <div className="col-span-2">


### PR DESCRIPTION
## Summary
- rename invoice downloads to receipts in Buyers and Purchases tables
- replace invoice API route with receipt route
- update tests for receipt downloading

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686034b3fd348329bc4760de87f347dd