### PR TITLE
Remove receipt download from seller page

### DIFF
--- a/app/buyers/columns.tsx
+++ b/app/buyers/columns.tsx
@@ -133,12 +133,6 @@ export function getColumns(
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
               <DropdownMenuLabel>Actions</DropdownMenuLabel>
-              <DropdownMenuItem
-                onClick={() => onAction(p._id, "receipt")}
-                disabled={!p.paymentIntentId && !p.invoiceId}
-              >
-                Download Receipt
-              </DropdownMenuItem>
               {p.paymentIntentId && p.status === "paid" && (
                 <DropdownMenuItem onClick={() => onAction(p._id, "refund")}>
                   Refund Purchase

--- a/app/buyers/page.tsx
+++ b/app/buyers/page.tsx
@@ -56,18 +56,6 @@ export default function BuyersPage() {
 
     if (action === "approve" || action === "decline") {
       setActionInfo({ id, type: action });
-    } else if (action === "receipt") {
-      // Open a blank tab immediately so popup blockers allow navigation
-      const newTab = window.open("", "_blank");
-      const res = await fetch(`/api/purchases/${id}/receipt`);
-      const data = await res.json().catch(() => ({}));
-      if (res.ok && data.url) {
-        if (newTab) newTab.location.href = data.url as string;
-        else window.location.href = data.url as string;
-      } else {
-        if (newTab) newTab.close();
-        toast.error(data.error || "Failed");
-      }
     } else if (action === "refund") {
       setActionInfo({ id, type: "refund" });
     }


### PR DESCRIPTION
## Summary
- hide "Download Receipt" action on buyers table
- remove obsolete handler case

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_6860c553d3cc83299ce3a3af893269fd